### PR TITLE
Override default recording behaviors based on recording

### DIFF
--- a/app/controllers/bigbluebutton_api_controller.rb
+++ b/app/controllers/bigbluebutton_api_controller.rb
@@ -135,7 +135,10 @@ class BigBlueButtonApiController < ApplicationController
     params.require(:meetingID)
 
     begin
-      server = Server.find_available
+        server = Server.find_available(false)
+        if params[:meta_doRecording].present? && params[:meta_doRecording] == "true"
+            server = Server.find_available(true)
+        end
     rescue ApplicationRedisRecord::RecordNotFound
       raise InternalError, 'Could not find any available servers.'
     end

--- a/app/controllers/bigbluebutton_api_controller.rb
+++ b/app/controllers/bigbluebutton_api_controller.rb
@@ -135,10 +135,8 @@ class BigBlueButtonApiController < ApplicationController
     params.require(:meetingID)
 
     begin
-        server = Server.find_available(false)
-        if params[:record].present? && params[:record] == "true"
-            server = Server.find_available(true)
-        end
+      wants_recording = params[:record] == "true"
+      server = Server.find_available(wants_recording)
     rescue ApplicationRedisRecord::RecordNotFound
       raise InternalError, 'Could not find any available servers.'
     end

--- a/app/controllers/bigbluebutton_api_controller.rb
+++ b/app/controllers/bigbluebutton_api_controller.rb
@@ -136,7 +136,7 @@ class BigBlueButtonApiController < ApplicationController
 
     begin
         server = Server.find_available(false)
-        if params[:meta_doRecording].present? && params[:meta_doRecording] == "true"
+        if params[:record].present? && params[:record] == "true"
             server = Server.find_available(true)
         end
     rescue ApplicationRedisRecord::RecordNotFound

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -162,13 +162,19 @@ class Server < ApplicationRedisRecord
   end
 
   # Find the server with the lowest load (for creating a new meeting)
-  def self.find_available
+  def self.find_available(for_recording)
     with_connection do |redis|
       id, load, hash = 5.times do
         ids_loads = redis.zrange('server_load', 0, 0, with_scores: true)
         raise RecordNotFound.new("Couldn't find available Server", name, nil) if ids_loads.blank?
-
         id, load = ids_loads.first
+        if(for_recording)
+            recording_servers = ["dummy_id"]
+            # we hard code the ids above for now
+            # filter out all servers that don't appear in our array
+            # expect data of the form [server_id, load]
+            id, load = ids_loads.select {|item| recording_servers.include?(item[0])}.first
+        end
         hash = redis.hgetall(key(id))
         break id, load, hash if hash.present?
       end

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -162,22 +162,21 @@ class Server < ApplicationRedisRecord
   end
 
   # Find the server with the lowest load (for creating a new meeting)
-  def self.find_available(for_recording)
+  def self.find_available(wants_recording)
     with_connection do |redis|
       id, load, hash = 5.times do
         ids_loads = redis.zrange('server_load', 0, 0, with_scores: true)
         raise RecordNotFound.new("Couldn't find available Server", name, nil) if ids_loads.blank?
-        recording_servers = ["dummy_id"]
-        id, load = ids_loads.first
-        if(for_recording)
-            # we hard code the ids above for now
-            # filter out all servers that don't appear in our array
-            # expect data of the form [server_id, load]
-            id, load = ids_loads.select {|item| recording_servers.include?(item[0])}.first
-        else
-            # filter out the unwanted servers meant for recording
-            id, load = ids_loads.select {|item| !recording_servers.include?(item[0])}.first
-        end
+
+        recording_servers = ["TODO"]
+        id, load = ids_loads.select { |item|
+          if wants_recording
+            recording_servers.include? item[0]
+          else
+            recording_servers.exclude? item[0]
+          end
+        }.first
+
         hash = redis.hgetall(key(id))
         break id, load, hash if hash.present?
       end

--- a/app/models/server.rb
+++ b/app/models/server.rb
@@ -167,13 +167,16 @@ class Server < ApplicationRedisRecord
       id, load, hash = 5.times do
         ids_loads = redis.zrange('server_load', 0, 0, with_scores: true)
         raise RecordNotFound.new("Couldn't find available Server", name, nil) if ids_loads.blank?
+        recording_servers = ["dummy_id"]
         id, load = ids_loads.first
         if(for_recording)
-            recording_servers = ["dummy_id"]
             # we hard code the ids above for now
             # filter out all servers that don't appear in our array
             # expect data of the form [server_id, load]
             id, load = ids_loads.select {|item| recording_servers.include?(item[0])}.first
+        else
+            # filter out the unwanted servers meant for recording
+            id, load = ids_loads.select {|item| !recording_servers.include?(item[0])}.first
         end
         hash = redis.hgetall(key(id))
         break id, load, hash if hash.present?

--- a/config/application.rb
+++ b/config/application.rb
@@ -42,7 +42,7 @@ module Scalelite
     config.x.redis_store = config_for(:redis_store)
 
     # Build number returned in the /bigbluebutton/api response
-    config.x.build_number = ENV['BUILD_NUMBER']
+    config.x.build_number = ENV['BUILD_NUMBER'] || `git describe --tags`
 
     # Secret used to verify /bigbluebutton/api requests
     config.x.loadbalancer_secret = ENV['LOADBALANCER_SECRET']


### PR DESCRIPTION
The idea is that all meeting create requests with `record=true parameter will if present and true only redirect to a server that is capable of recording.